### PR TITLE
Support Service Principal Authentication

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -417,3 +417,6 @@ dist
 
 # Virtual Environment
 venv/
+
+# If you are working on test scripts, place them in this directory to avoid being committed
+.ignore

--- a/README.md
+++ b/README.md
@@ -6,15 +6,24 @@ The Needlr packages provides a unified, cross-experience Microsoft Fabric SDK. T
 ## Quickstart
 Needlr is available on [PyPi](https://pypi.org/project/needlr/) and can be installed via `pip install needlr`.
 
-With needlr installed, you first authenticate by creating a Fabric client. You can use either [auth.FabricInteractiveAuth](https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.interactivebrowsercredential?view=azure-python) to use your personal credentials or `auth.FabricServicePrincipal` to use a service principal (which is supported for most but not all APIs).
+With needlr installed, you first authenticate by creating a Fabric client. You can use either [FabricInteractiveAuth](https://learn.microsoft.com/en-us/python/api/azure-identity/azure.identity.interactivebrowsercredential?view=azure-python) to use your personal credentials or `FabricServicePrincipal` to use a service principal (which is supported for most but not all APIs).
 
 ```python
 from needlr import auth, FabricClient
+from needlr.auth import FabricInteractiveAuth
 
-fc = FabricClient(
-    auth=auth.FabricInteractiveAuth(
-        scopes=['https://api.fabric.microsoft.com/.default'])
-    )
+fc = FabricClient(auth=auth.FabricInteractiveAuth())
+for ws in fc.workspace.ls():
+    print(f"{ws.name}: Id:{ws.id} Capacity:{ws.capacityId}")
+```
+You use Service Principals in a similar way by bringing in the app id, secret, and tenant id. Replace the strings below with your service principals information.
+
+```python
+from needlr import auth, FabricClient
+from needlr.auth import FabricServicePrincipal
+
+auth = FabricServicePrincipal("APP_ID", "APP_SECRET", "TENANT_ID")
+fc = FabricClient(auth=auth)
 for ws in fc.workspace.ls():
     print(f"{ws.name}: Id:{ws.id} Capacity:{ws.capacityId}")
 ```

--- a/needlr/auth/scopes.py
+++ b/needlr/auth/scopes.py
@@ -1,4 +1,4 @@
-
+DEFAULT = "https://api.fabric.microsoft.com/.default"
 WORKSPACE_RW_ALL = "https://api.fabric.microsoft.com/Workspace.ReadWrite.All"
 ITEM_RW_ALL = "https://api.fabric.microsoft.com/Item.ReadWrite.All"
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -2,6 +2,10 @@
 
 Needlr is designed to support Microsoft Fabric deployments and automation. It provides a set of foundational capabilities that you can use to build amazing new workflows. This repository of samples are just a small collection of what is possible with needlr!
 
+## Getting Started
+
+* [List Workspaces and Confirm Connectivity](./workspaces_list.py)
+
 ## Data Science
 
 * [Data Science Project](./datascienceproject.py)

--- a/samples/workspaces_list.py
+++ b/samples/workspaces_list.py
@@ -1,0 +1,25 @@
+# This sample demonstrates the bare bones of connecting to Fabric through
+# Needlr and listing all of the workspaces they have access to.
+# This is a great way to test your connectivity.
+
+import os
+from dotenv import load_dotenv
+from needlr.auth import FabricServicePrincipal, FabricInteractiveAuth
+from needlr import FabricClient
+
+auth = FabricInteractiveAuth()
+
+# If you're testing with a service principal uncomment this section
+
+# load_dotenv()
+# APP_ID=os.environ.get("APP_ID")
+# TENANT_ID=os.environ.get("TENANT_ID")
+# APP_SECRET=os.environ.get("APP_SECRET")
+#auth = FabricServicePrincipal(APP_ID,APP_SECRET,TENANT_ID)
+
+fc = FabricClient(auth)
+
+for ws in fc.workspace.ls():
+    print(f"{ws.name}: Id:{ws.id} Capacity:{ws.capacityId}")
+    for itm in fc.workspace.item_ls(ws.id):
+        print(f"\t{itm.displayName}:{itm.type}")


### PR DESCRIPTION
* Added support for using a service principal to login
* Updated the README to reflect the change
* Added a sample to demonstrate listing a workspace but more importantly confirm connectivity
* Added a default scope to Interactive (and SPN) Auth so that users didn't have to specify but can always override.