### PR TITLE
Support automated deployment to PyPi

### DIFF
--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -58,5 +58,49 @@ jobs:
     - name: Store the distribution packages
       uses: actions/upload-artifact@v4
       with:
-        name: needlr-${{github.sha}}
+        name: python-package-distributions
         path: dist/
+  publish-to-test-pypi:
+    name: >-
+      Test ⚠️ Publish Python 🐍 distribution 📦
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - package
+    runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+      url: https://test.pypi.org/p/needlr
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Test ⚠️ Publish distribution 📦
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+  publish-to-pypi:
+    name: >-
+      Publish Python 🐍 distribution 📦 to PyPI
+    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    needs:
+    - publish-to-test-pypi
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/needlr
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/checkout@v2
+    - name: Download all the dists
+      uses: actions/download-artifact@v4
+      with:
+        name: python-package-distributions
+        path: dist/
+    - name: Publish distribution 📦 to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
- Updated artifact upload to python-package-distributions
- Had to manually configure trusted publishing on Test and real PyPi
- Create publish to test pypi job that references package job
- Create publish to real pypi job that requires the test pypi path to succeed
  - In the future, may need to consider what we do if test pypi succeeds but real pypi fails

In the future, should consider executing a script to test the package is installable
In the future, should consider executing a notebook in Fabric

The code was developed on the side from this test repo to confirm it works without attempting to deploy to our production pypi repo.