### PR TITLE
Fix access to dev dependencies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ docstring-code-format = false
 # enabled.
 docstring-code-line-length = "dynamic"
 
-[dependency-groups]
+[project.optional-dependencies]
 dev = [
     "annotated-types==0.7.0",
     "azure-identity>=1.19.0",


### PR DESCRIPTION
Switch "[dependency-groups]" for "[project.optional-dependencies]". Fixes bug/issue for users trying to install developer dependencies.

-----
To test:

- For uv:
`uv pip install .[dev]`

- For pip:
`pip install .[dev]`