### PR TITLE
Update item types pydantic model

### DIFF
--- a/needlr/models/item.py
+++ b/needlr/models/item.py
@@ -9,24 +9,31 @@ class ItemType(str, Enum):
     """
     [Reference](https://learn.microsoft.com/en-us/rest/api/fabric/core/items/list-items?tabs=HTTP#itemtype)
     """
+    ApacheAirflowProject = 'ApacheAirflowProject'
     Dashboard = 'Dashboard'
     DataPipeline = 'DataPipeline'
     Datamart = 'Datamart'
     Environment = 'Environment'
     Eventhouse = 'Eventhouse'
     Eventstream = 'Eventstream'
+    GraphQLApi = 'GraphQLApi'
+    KQLDashboard = 'KQLDashboard'
     KQLDatabase = 'KQLDatabase'
     KQLQueryset = 'KQLQueryset'
     Lakehouse = 'Lakehouse'
+    MLExperiment = 'MLExperiment'
     MLModel = 'MLModel'
+    MirroredDatabase = 'MirroredDatabase'
     MirroredWarehouse = 'MirroredWarehouse'
+    MountedDataFactory = 'MountedDataFactory'
     Notebook = 'Notebook'
+    OrgApp = 'OrgApp'
     PaginatedReport = 'PaginatedReport'
+    Reflex = 'Reflex'
     Report = 'Report'
     SQLEndpoint = 'SQLEndpoint'
     SemanticModel = 'SemanticModel'
     SparkJobDefinition = 'SparkJobDefinition'
-    SynapseNotebook = 'SynapseNotebook'
     Warehouse = 'Warehouse'
 
 class Item(BaseModel):


### PR DESCRIPTION
Adding missing item types to the pydantic model. This is a fix so that listing of items within a workspace does not fail.