### PR TITLE
Fix multiple PrincipalType default values

### DIFF
--- a/needlr/models/workspace.py
+++ b/needlr/models/workspace.py
@@ -37,13 +37,13 @@ class GroupPrincipal(_Principal):
     type: Literal[PrincipalType.Group] = PrincipalType.Group
 
 class ServicePrincipal(_Principal):
-    type: Literal[PrincipalType.ServicePrincipal]
+    type: Literal[PrincipalType.ServicePrincipal] = PrincipalType.ServicePrincipal
 
 class UserPrincipal(_Principal):
-    type: Literal[PrincipalType.User]
+    type: Literal[PrincipalType.User] = PrincipalType.User
 
 class ServicePrincipalProfile(_Principal):
-    type: Literal[PrincipalType.ServicePrincipalProfile]
+    type: Literal[PrincipalType.ServicePrincipalProfile] = PrincipalType.ServicePrincipalProfile
 
 class WorkspaceType(str, Enum):
     """


### PR DESCRIPTION
This allows the easy creation of different type of Principals without having to explicitly defined their type. It should be implicit based on the sub class used