### PR TITLE
Fixed issue with missing ItemType

### DIFF
--- a/needlr/models/item.py
+++ b/needlr/models/item.py
@@ -2,7 +2,7 @@
 
 from enum import Enum
 import uuid
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class ItemType(str, Enum):
@@ -31,11 +31,10 @@ class ItemType(str, Enum):
 
 class Item(BaseModel):
     id: uuid.UUID = None
-    type: ItemType = None   # In case new types how up, this will be None
+    type: ItemType | str   # In case new types how up, this will be None
     displayName: str
     description: str = None
     definition:dict = None
     workspaceId: uuid.UUID = None
     properties: dict = None
     parentDomainId: str = None
-

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -48,7 +48,15 @@ def testParameters():
     }
 @pytest.fixture(scope='session')
 def fc() -> FabricClient:
-    return FabricClient(auth=auth.FabricInteractiveAuth(scopes=['https://api.fabric.microsoft.com/.default']))
+    if os.getenv('APP_ID'):
+        authorization = auth.FabricServicePrincipal(
+            client_id=os.getenv('APP_ID'),
+            client_secret=os.getenv('APP_SECRET'),
+            tenant_id=os.getenv('TENANT_ID')
+        )
+    else:
+        authorization = auth.FabricInteractiveAuth()
+    return FabricClient(auth=authorization)
 
 @pytest.fixture(scope='session')
 def workspace_test(fc: FabricClient, testParameters) -> Generator[Workspace, None, None]:


### PR DESCRIPTION
type member on base Item class now can be an ItemType (for supported Item Types) or a String (for unsupported ones)