### PR TITLE
Fixed Item type when used on requests (not results)

### DIFF
--- a/needlr/models/item.py
+++ b/needlr/models/item.py
@@ -38,7 +38,7 @@ class ItemType(str, Enum):
 
 class Item(BaseModel):
     id: uuid.UUID = None
-    type: ItemType | str = None  # In case new types how up, this will be None
+    type: ItemType | str = None  # In case new types show up, this will be None
     displayName: str
     description: str = None
     definition:dict = None

--- a/needlr/models/item.py
+++ b/needlr/models/item.py
@@ -38,7 +38,7 @@ class ItemType(str, Enum):
 
 class Item(BaseModel):
     id: uuid.UUID = None
-    type: ItemType | str   # In case new types how up, this will be None
+    type: ItemType | str = None  # In case new types how up, this will be None
     displayName: str
     description: str = None
     definition:dict = None


### PR DESCRIPTION
Urgent fixed required to deal with Needlr requests that use Item type as body and do not specify an ItemType