### PR TITLE
Feature: Add Reflex

### DIFF
--- a/needlr/client.py
+++ b/needlr/client.py
@@ -21,6 +21,7 @@ from needlr.realtimeintelligence.kqlqueryset import _KQLQuerySetClient
 from needlr.admin.domain import _DomainClient
 from needlr.datascience.mlmodel import _MLModelClient
 from needlr.datascience.mlexperiment import _MLExperimentClient
+from needlr.dataactivator.reflex.reflex import _ReflexClient
 
 
 
@@ -51,4 +52,5 @@ class FabricClient():
         self.domain = _DomainClient(auth=auth, base_url=self._base_url)
         self.mlmodel = _MLModelClient(auth=auth, base_url=self._base_url)
         self.mlexperiment = _MLExperimentClient(auth=auth, base_url=self._base_url)
+        self.reflex = _ReflexClient(auth=auth, base_url=self._base_url)
 

--- a/needlr/dataactivator/reflex/reflex.py
+++ b/needlr/dataactivator/reflex/reflex.py
@@ -1,0 +1,235 @@
+from collections.abc import Iterator
+import uuid
+
+from needlr._http import FabricResponse
+from needlr import _http
+from needlr.auth.auth import _FabricAuthentication
+from needlr.models.reflex import Reflex
+from needlr.models.item import Item
+
+class _ReflexClient():
+    """
+
+    [Reference]()
+
+    ### Coverage
+
+    * Create Reflex > create()
+    * Delete Reflex > delete()
+    * Get Reflex > get()
+    * Get Reflex Definition > get_definition()
+    * List Reflexes > ls()
+    * Update Reflex > update()
+    * Update Reflex Definition > update_definition()
+    
+    """
+
+
+    def __init__(self, auth: _FabricAuthentication, base_url):
+        """
+        Initializes a new instance of the Reflex class.
+
+        Args:
+            auth (_FabricAuthentication): The authentication object used for authentication.
+            base_url (str): The base URL of the Reflex.
+        """
+        self._auth = auth
+        self._base_url = base_url
+
+    def create(self, workspace_id:uuid.UUID, display_name:str, definition: str=None, description:str=None) -> Reflex:
+        """
+        Create Reflex
+
+        This method creates a Reflex in the specified workspace.
+
+        Args:
+            workspace_id (uuid.UUID): The ID of the workspace where the Reflex will be created.
+            display_name (str): The display name of the Reflex.
+            description (str, optional): The description of the Reflex. Defaults to None.
+
+        Returns:
+            Reflex: The created Reflex.
+
+        Reference:
+        [Create Reflex](https://learn.microsoft.com/en-us/rest/api/fabric/reflex/items/create-reflex?tabs=HTTP)
+        """
+        body = {
+            "displayName":display_name
+        }
+        
+        if definition:
+            body["definition"] = definition
+        
+        if description:
+            body["description"] = description
+
+        resp = _http._post_http_long_running(
+            url = f"{self._base_url}workspaces/{workspace_id}/reflexes",
+            auth=self._auth,
+            item=Reflex(**body)
+        )
+        reflex = Reflex(**resp.body)
+        return reflex
+    
+    def delete(self, workspace_id:uuid.UUID, reflex_id:uuid.UUID) -> FabricResponse:
+        """
+        Delete Reflex
+
+        Deletes a Reflex from a workspace.
+
+        Args:
+            workspace_id (uuid.UUID): The ID of the workspace.
+            reflex_id (uuid.UUID): The ID of the Reflex.
+
+        Returns:
+            FabricResponse: The response from the delete request.
+
+        Reference:
+            [Delete Reflex](https://learn.microsoft.com/en-us/rest/api/fabric/reflex/items/delete-reflex?tabs=HTTP)
+        """
+        resp = _http._delete_http(
+            url = f"{self._base_url}workspaces/{workspace_id}/reflexes/{reflex_id}",
+            auth=self._auth
+        )
+        return resp
+    
+    def get(self, workspace_id:uuid.UUID, reflex_id:uuid.UUID) -> Reflex:
+        """
+        Get Reflex
+
+        Retrieves a Reflex from the specified workspace.
+
+        Args:
+            workspace_id (uuid.UUID): The ID of the workspace containing the Reflex.
+            reflex_id (uuid.UUID): The ID of the Reflex to retrieve.
+
+        Returns:
+            Reflex: The retrieved Reflex.
+
+        References:
+            - [Get Reflex](https://learn.microsoft.com/en-us/rest/api/fabric/reflex/items/get-reflex?tabs=HTTP)
+        """
+        resp = _http._get_http(
+            url = f"{self._base_url}workspaces/{workspace_id}/reflexes/{reflex_id}",
+            auth=self._auth
+        )
+        reflex = Reflex(**resp.body)
+        return reflex
+    
+    def get_definition(self, workspace_id:uuid.UUID, reflex_id:uuid.UUID, format: str) -> dict:
+        """
+        Get Reflex Definition
+
+        Retrieves the definition of a reflex for a given workspace and reflex ID.
+
+        Args:
+            workspace_id (uuid.UUID): The ID of the workspace.
+            reflex_id (uuid.UUID): The ID of the reflex.
+
+        Returns:
+            dict: The definition of the reflex.
+
+        Raises:
+            SomeException: If there is an error retrieving the reflex definition.
+
+        Reference:
+        - [Get Reflex Definition](https://learn.microsoft.com/en-us/rest/api/fabric/reflex/items/get-reflex-definition?tabs=HTTP)
+        """
+
+        flag = f'?format={format}' if format else ''
+        try:
+            resp = _http._post_http_long_running(
+                url = f"{self._base_url}workspaces/{workspace_id}/reflexes/{reflex_id}/getDefinition{flag}",
+                auth=self._auth
+            )
+            if resp.is_successful:
+                return resp.body['definition']
+            else:
+                return None
+        except Exception:
+             raise Exception("Error getting reflex definition")
+
+    def ls(self, workspace_id:uuid.UUID, continuation_token: str) -> Iterator[Reflex]:
+            """
+            List Reflex
+
+            Retrieves a list of Reflexes associated with the specified workspace ID.
+
+            Args:
+                workspace_id (uuid.UUID): The ID of the workspace.
+                continuation_token (str, optional): A token for retrieving the next page of results.
+
+            Yields:
+                Iterator[Reflex]: An iterator of Reflex objects.
+
+            Reference:
+                [List Reflexes](https://learn.microsoft.com/en-us/rest/api/fabric/reflex/items/list-reflexes?tabs=HTTP)
+            """
+            resp = _http._get_http_paged(
+                url = f"{self._base_url}workspaces/{workspace_id}/reflexes",
+                auth=self._auth,
+                items_extract=lambda x:x["value"]
+            )
+            for page in resp:
+                for item in page.items:
+                    yield Reflex(**item)
+
+    def update(self, workspace_id:uuid.UUID, reflex_id:uuid.UUID) -> Reflex:
+        """
+        Update Reflex
+
+        This method updates the definition of a Reflex in Fabric.
+
+        Args:
+            workspace_id (uuid.UUID): The ID of the workspace where the Reflex is located.
+            reflex_id (uuid.UUID): The ID of the Reflex to update.
+
+        Returns:
+            Reflex: The updated Reflex object.
+
+        Reference:
+        - [Update Reflex](https://learn.microsoft.com/en-us/rest/api/fabric/reflex/items/update-reflex?tabs=HTTP)
+        """
+        body = dict()
+
+        resp = _http._patch_http(
+            url = f"{self._base_url}workspaces/{workspace_id}/reflexes/{reflex_id}",
+            auth=self._auth,
+            item=Item(**body)
+        )
+        return resp
+
+    def update_definition(self, workspace_id:uuid.UUID, reflex_id:uuid.UUID, definition:dict, updateMetadata:bool = False) -> Reflex:
+            """
+            Update Reflex Definition
+            
+            This method updates the definition of a reflex for a given workspace and reflex ID.
+            
+            Args:
+                workspace_id (uuid.UUID): The ID of the workspace.
+                reflex_id (uuid.UUID): The ID of the reflex.
+                definition (dict): The new definition for the reflex.
+
+            Returns:
+                Reflex: The updated reflex object.
+
+            Raises:
+                SomeException: If there is an error updating the reflex definition. 
+
+            Reference:
+            - [Update Reflex Definition](https://learn.microsoft.com/en-us/rest/api/fabric/reflex/items/update-reflex-definition?tabs=HTTP)
+            """
+
+            flag = f'?updateMetadata={updateMetadata}' if updateMetadata else ''
+            try:
+                resp = _http._post_http_long_running(
+                    url = f"{self._base_url}workspaces/{workspace_id}/reflexes/{reflex_id}/updateDefinition{flag}",
+                    auth=self._auth,
+                    json_par=definition
+                )
+                if resp.is_successful:
+                    return self.get(workspace_id, reflex_id, include_definition=True)
+                else:
+                        return None
+            except Exception:
+                    raise Exception("Error updating reflex definition")

--- a/needlr/models/reflex.py
+++ b/needlr/models/reflex.py
@@ -1,0 +1,10 @@
+import uuid
+
+from pydantic import AliasChoices, BaseModel, Field
+
+from needlr.models.item import ItemType, Item
+
+
+class Reflex(Item):
+    name: str = Field(validation_alias=AliasChoices('displayName'))
+    type: ItemType = ItemType.Reflex

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,7 @@ from needlr.models.workspace import Workspace
 from needlr.models.domain import Domain
 from needlr.models.mlmodel import MLModel
 from needlr.models.mlexperiment import MLExperiment
+from needlr.models.reflex import Reflex
 import os
 
 # Loading an Environment Variable File with dotenv
@@ -60,7 +61,13 @@ def testParameters():
         'mlexperiment_displayName': 'ML Experiment Display Name',
         'mlexperiment_description': 'ML Experiment Description',
         'mlexperiment_id': 'The ML Experiment ID',
-        'mlexperiment_continuation_token': 'Optional | A token for retrieving the next page of results'
+        'mlexperiment_continuation_token': 'Optional | A token for retrieving the next page of results',
+        'reflex_displayName': 'Reflex Display Name',
+        'reflex_definition': 'Reflex Public Definition',
+        'reflex_description': 'Reflex Description',
+        'reflex_format': 'Format of the Reflex public definition',
+        'reflex_continuation_token': 'Optional | A token for retrieving the next page of results',
+        'reflex_updateMetadata': 'Optional | Boolean | Update Item Metadata'
     }
 @pytest.fixture(scope='session')
 def fc() -> FabricClient:
@@ -103,3 +110,11 @@ def mlexperiment_test(fc: FabricClient, testParameters) -> Generator[MLExperimen
                                 display_name=testParameters['mlexperiment_displayName'],
                                 description=testParameters['mlexperiment_description'])
     yield me
+
+@pytest.fixture(scope='session')
+def reflex_test(fc: FabricClient, testParameters) -> Generator[Reflex, None, None]:
+    r = fc.mlexperiment.create(workspace_id=testParameters['workspace_id'],
+                                display_name=testParameters['reflex_displayName'],
+                                definition=testParameters['reflex_definition'],
+                                description=testParameters['reflex_description'])
+    yield r

--- a/tests/dataactivator/conftest.py
+++ b/tests/dataactivator/conftest.py
@@ -1,0 +1,12 @@
+import pytest
+from typing import Generator
+from needlr import FabricClient
+from needlr.models.reflex import Reflex
+
+@pytest.fixture(scope='session')
+def reflex_test(fc: FabricClient, testParameters) -> Generator[Reflex, None, None]:
+    r = fc.mlexperiment.create(workspace_id=testParameters['workspace_id'],
+                                display_name=testParameters['reflex_displayName'],
+                                definition=testParameters['reflex_definition'],
+                                description=testParameters['reflex_description'])
+    yield r

--- a/tests/dataactivator/test_reflex.py
+++ b/tests/dataactivator/test_reflex.py
@@ -1,0 +1,38 @@
+import pytest
+from needlr import FabricClient
+from needlr.models.workspace import Workspace
+from needlr.models.reflex import Reflex
+
+class TestReflexLifeCycle:
+
+    def test_reflex_ls(self, fc: FabricClient, workspace_test: Workspace, reflex_test: Reflex):
+        ref = fc.reflex.ls(workspace_id=workspace_test.id)
+        for r in list(ref):
+            if r.id == reflex_test.id:
+                assert True
+                return
+    
+    @pytest.mark.order(after="test_reflex_ls")
+    def test_reflex_get(self, fc: FabricClient, workspace_test: Workspace, reflex_test: Reflex):
+        ref = fc.reflex.get(workspace_id=workspace_test.id, reflex_id=reflex_test.id)
+        assert ref is not None
+
+    @pytest.mark.order(after="test_reflex_get")
+    def test_reflex_update(self, fc: FabricClient, workspace_test: Workspace, reflex_test: Reflex, testParameters: dict[str, str]):
+        ref = fc.reflex.update(workspace_id=workspace_test.id, reflex_id=reflex_test.id, display_name='new'+testParameters['reflex_displayName'],description='New'+testParameters['reflex_description'])
+        assert type(ref) is Reflex
+
+    @pytest.mark.order(after="test_reflex_update")
+    def test_reflex_update_definition(self, fc: FabricClient, workspace_test: Workspace, reflex_test: Reflex, testParameters: dict[str, str]):
+        ref = fc.reflex.update_definition(workspace_id=workspace_test.id, reflex_id=reflex_test.id, update_metadata=testParameters['reflex_updateMetadata'], definition=testParameters['reflex_definition'])
+        assert type(ref) is Reflex
+
+    @pytest.mark.order(after="test_reflex_update_definition")
+    def test_reflex_get_definition(self, fc: FabricClient, workspace_test: Workspace, reflex_test: Reflex):
+        definition = fc.reflex.get_definition(workspace_id=workspace_test.id, reflex_id=reflex_test.id)
+        assert definition is not None
+    
+    @pytest.mark.order(after="test_reflex_get_definition")
+    def test_reflex_delete(self, fc: FabricClient, workspace_test: Workspace, reflex_test: Reflex):
+        ref = fc.reflex.delete(workspace_id=workspace_test.id, reflex_id=reflex_test.id)
+        assert ref.is_successful is True


### PR DESCRIPTION
Changes:

- `needlr/models/reflex.py`
   * Added `Reflex` model class to represent Reflex items
- `needlr/dataactivator/reflex/`
   * Deleted placeholder file
- `needlr/dataactivator/reflex/reflex.py`
   * Created a `_ReflexClient` class with the following methods: create, delete, get, get_definition, ls, update, and update_definition
- `needlr/client.py`
   * Add the `_ReflexClient` class
- `tests/conftest.py`
   * Included `Reflex`-related parameters in the `testParameters` dictionary
   * Added a `reflex_test` fixture
- `tests/dataactivator/conftest.py`
   * Added a `reflex_test` fixture
- `tests/dataactivator/test_reflex.py`
   * Added tests to check the Reflex lifecycle, including listing, getting, updating, and deleting