### PR TITLE
Fix: datascience/mlexperiment

### DIFF
--- a/needlr/datascience/mlexperiment.py
+++ b/needlr/datascience/mlexperiment.py
@@ -136,7 +136,7 @@ class _MLExperimentClient():
                 for item in page.items:
                     yield MLExperiment(**item)
 
-    def update(self, workspace_id:uuid.UUID, mlexperiment_id:uuid.UUID) -> MLExperiment:
+    def update(self, workspace_id:uuid.UUID, mlexperiment_id:uuid.UUID, display_name: str, description: str) -> MLExperiment:
         """
         Update ML Experiment
 
@@ -145,6 +145,8 @@ class _MLExperimentClient():
         Args:
             workspace_id (uuid.UUID): The ID of the workspace where the ML Experiment is located.
             mlexperiment_id (uuid.UUID): The ID of the ML Experiment to update.
+            display_name (str): The ML Experiment display name.
+            description (str): The ML Experiment description.
 
         Returns:
             MLExperiment: The updated ML Experiment object.
@@ -152,11 +154,19 @@ class _MLExperimentClient():
         Reference:
         - [Update ML Experiment Definition](https://learn.microsoft.com/en-us/rest/api/fabric/mlexperiment/items/update-ml-experiment?tabs=HTTP)
         """
+        if ((display_name is None) and (description is None)):
+            raise ValueError("display_name or description must be provided")
+
         body = dict()
+        if display_name:
+            body["displayName"] = display_name
+        if description:
+            body["description"] = description
 
         resp = _http._patch_http(
             url = f"{self._base_url}workspaces/{workspace_id}/mlExperiments/{mlexperiment_id}",
             auth=self._auth,
-            item=Item(**body)
+            json=body
         )
-        return resp
+        mlExperiment = MLExperiment(**resp.body)
+        return mlExperiment


### PR DESCRIPTION
File changed:

- `needlr/datascience/mlexperiment.py`
   * Made continuation_token an optional parameter by adding `=None`
   * Updated `update()` to include `display_name (str)` and `description (str)` as required parameters, add in new required parameters as part of the args in the docstrings, and revised the code to leverage the required parameters